### PR TITLE
Set explicit platform targets

### DIFF
--- a/src/Maui.TouchEffect/Maui.TouchEffect.csproj
+++ b/src/Maui.TouchEffect/Maui.TouchEffect.csproj
@@ -28,6 +28,12 @@
         <PackageProjectUrl>https://github.com/Axemasta/Maui.TouchEffect</PackageProjectUrl>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+
+        <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">15.0</SupportedOSPlatformVersion>
+        <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">15.0</SupportedOSPlatformVersion>
+        <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">21.0</SupportedOSPlatformVersion>
+        <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>
+        <TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
When installing 1.1.8 in my project, i saw the following error:
```
4>MyApp.csproj: Error NU1202 : Package Axemasta.Maui.TouchEffect 1.1.8 is not compatible with net9.0 (.NETCoreApp,Version=v9.0). Package Axemasta.Maui.TouchEffect 1.1.8 supports:
  - net9.0-android35.0 (.NETCoreApp,Version=v9.0)
  - net9.0-ios18.0 (.NETCoreApp,Version=v9.0)
  - net9.0-maccatalyst18.0 (.NETCoreApp,Version=v9.0)
  - net9.0-windows10.0.19041 (.NETCoreApp,Version=v9.0)
```

I've set the defaults to what the MCT uses.