### PR TITLE
Add .net9.0 target

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,13 +11,17 @@
 
         <NetVersion>9</NetVersion>
 
+        <StandardTargetFramework>net$(NetVersion).0</StandardTargetFramework>
         <IosTargetFramework>net$(NetVersion).0-ios</IosTargetFramework>
         <AndroidTargetFramework>net$(NetVersion).0-android</AndroidTargetFramework>
         <MacTargetFramework>net$(NetVersion).0-maccatalyst</MacTargetFramework>
         <WindowsTargetFramework>net$(NetVersion).0-windows10.0.19041.0</WindowsTargetFramework>
 
         <MauiPlatformTargetFrameworks>$(AndroidTargetFramework);$(IosTargetFramework);$(MacTargetFramework)</MauiPlatformTargetFrameworks>
-        <MauiPlatformTargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(StandardTargetFramework);$(AndroidTargetFramework);$(IosTargetFramework);$(MacTargetFramework);$(WindowsTargetFramework)</MauiPlatformTargetFrameworks>
+        <MauiPlatformTargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(AndroidTargetFramework);$(IosTargetFramework);$(MacTargetFramework);$(WindowsTargetFramework)</MauiPlatformTargetFrameworks>
+
+        <LibraryPlatformTargetFrameworks>$(StandardTargetFramework);$(AndroidTargetFramework);$(IosTargetFramework);$(MacTargetFramework)</LibraryPlatformTargetFrameworks>
+        <LibraryPlatformTargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(StandardTargetFramework);$(AndroidTargetFramework);$(IosTargetFramework);$(MacTargetFramework);$(WindowsTargetFramework)</LibraryPlatformTargetFrameworks>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/src/Maui.TouchEffect/Maui.TouchEffect.csproj
+++ b/src/Maui.TouchEffect/Maui.TouchEffect.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>$(MauiPlatformTargetFrameworks);</TargetFrameworks>
+        <TargetFrameworks>$(LibraryPlatformTargetFrameworks);</TargetFrameworks>
         <UseMaui>true</UseMaui>
         <SingleProject>true</SingleProject>
         <ImplicitUsings>enable</ImplicitUsings>


### PR DESCRIPTION
Ensure the library targets .net9 to prevent compatibility with projects that target net9.0