### PR TITLE
Fix LongPressDuration Crash When Using Xaml SourceGen

### DIFF
--- a/samples/Maui.TouchEffect.Sample/Maui.TouchEffect.Sample/Maui.TouchEffect.Sample.csproj
+++ b/samples/Maui.TouchEffect.Sample/Maui.TouchEffect.Sample/Maui.TouchEffect.Sample.csproj
@@ -8,6 +8,8 @@
         <SingleProject>true</SingleProject>
         <ImplicitUsings>enable</ImplicitUsings>
 
+        <MauiXamlInflator>SourceGen</MauiXamlInflator>
+        
         <!-- Display name -->
         <ApplicationTitle>Maui.TouchEffect.Sample</ApplicationTitle>
 

--- a/samples/Maui.TouchEffect.Sample/Maui.TouchEffect.Sample/Pages/ImagePage.xaml
+++ b/samples/Maui.TouchEffect.Sample/Maui.TouchEffect.Sample/Pages/ImagePage.xaml
@@ -14,8 +14,8 @@
 
     <ContentPage.Resources>
         <Style x:Key="GridRowContentStyle" TargetType="StackLayout">
-            <Setter Property="HorizontalOptions" Value="CenterAndExpand" />
-            <Setter Property="VerticalOptions" Value="CenterAndExpand" />
+            <Setter Property="HorizontalOptions" Value="Center" />
+            <Setter Property="VerticalOptions" Value="Center" />
             <Setter Property="Spacing" Value="10" />
         </Style>
     </ContentPage.Resources>
@@ -24,8 +24,8 @@
 
         <StackLayout Orientation="Horizontal">
             <Label
-                FontSize="Title"
-                HorizontalOptions="FillAndExpand"
+                FontSize="{StaticResource FontSizeTitle}"
+                HorizontalOptions="Fill"
                 Text="NativeAnimationBorderless" />
             <Switch IsToggled="{Binding NativeAnimationBorderless}" />
         </StackLayout>

--- a/samples/Maui.TouchEffect.Sample/Maui.TouchEffect.Sample/Pages/TouchEffectPage.xaml
+++ b/samples/Maui.TouchEffect.Sample/Maui.TouchEffect.Sample/Pages/TouchEffectPage.xaml
@@ -2,16 +2,16 @@
 
 <ContentPage
     x:Class="Maui.TouchEffect.Sample.Pages.TouchEffectPage"
-    x:DataType="viewmodels:TouchEffectViewModel"
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:touch="http://axemasta.com/schemas/2023/toucheffect"
     xmlns:viewmodels="clr-namespace:Maui.TouchEffect.Sample.ViewModels"
-    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
+    x:DataType="viewmodels:TouchEffectViewModel">
 
     <ContentPage.Resources>
-        <Style TargetType="StackLayout" x:Key="GridRowContentStyle">
-            <Setter Property="HorizontalOptions" Value="CenterAndExpand" />
-            <Setter Property="VerticalOptions" Value="CenterAndExpand" />
+        <Style x:Key="GridRowContentStyle" TargetType="StackLayout">
+            <Setter Property="HorizontalOptions" Value="Center" />
+            <Setter Property="VerticalOptions" Value="Center" />
             <Setter Property="Spacing" Value="10" />
         </Style>
     </ContentPage.Resources>
@@ -25,15 +25,15 @@
 
             <StackLayout Orientation="Horizontal">
                 <Label
-                    FontSize="Title"
-                    HorizontalOptions="FillAndExpand"
+                    FontSize="{StaticResource FontSizeTitle}"
+                    HorizontalOptions="Fill"
                     Text="NativeAnimationBorderless" />
                 <Switch IsToggled="{Binding NativeAnimationBorderless}" />
             </StackLayout>
 
             <Label
-                FontSize="Title"
-                HorizontalOptions="CenterAndExpand"
+                FontSize="{StaticResource FontSizeTitle}"
+                HorizontalOptions="Center"
                 Text="{Binding TouchCount, StringFormat='Touches: {0}'}" />
 
             <StackLayout Style="{StaticResource GridRowContentStyle}">
@@ -41,22 +41,22 @@
                 <Label Text="Scale | Fade | Animated" />
 
                 <StackLayout
-                    HorizontalOptions="CenterAndExpand"
-                    Orientation="Horizontal"
                     touch:TouchEffect.Command="{Binding TouchCommand}"
                     touch:TouchEffect.DefaultAnimationDuration="250"
                     touch:TouchEffect.DefaultAnimationEasing="{x:Static Easing.CubicInOut}"
                     touch:TouchEffect.PressedOpacity="0.6"
-                    touch:TouchEffect.PressedScale="0.8">
+                    touch:TouchEffect.PressedScale="0.8"
+                    HorizontalOptions="Center"
+                    Orientation="Horizontal">
                     <BoxView
-                        Color="Gold"
                         HeightRequest="20"
-                        WidthRequest="20" />
+                        WidthRequest="20"
+                        Color="Gold" />
                     <Label Text="The entire layout receives touches" />
                     <BoxView
-                        Color="Gold"
                         HeightRequest="20"
-                        WidthRequest="20" />
+                        WidthRequest="20"
+                        Color="Gold" />
                 </StackLayout>
             </StackLayout>
 
@@ -65,23 +65,23 @@
                 <Label Text="Native | Long Press | Hover" />
 
                 <Label
-                    FontSize="Body"
-                    HorizontalOptions="CenterAndExpand"
+                    FontSize="{StaticResource FontSizeBody}"
+                    HorizontalOptions="Center"
                     Text="{Binding LongPressCount, StringFormat='Long press count: {0}'}" />
 
                 <StackLayout
-                    BackgroundColor="Black"
-                    HorizontalOptions="CenterAndExpand"
-                    Orientation="Horizontal"
                     Padding="20"
                     touch:TouchEffect.Command="{Binding TouchCommand}"
                     touch:TouchEffect.HoveredScale="1.2"
                     touch:TouchEffect.LongPressCommand="{Binding LongPressCommand}"
                     touch:TouchEffect.LongPressDuration="3000"
                     touch:TouchEffect.NativeAnimation="True"
-                    touch:TouchEffect.NativeAnimationBorderless="{Binding NativeAnimationBorderless}">
+                    touch:TouchEffect.NativeAnimationBorderless="{Binding NativeAnimationBorderless}"
+                    BackgroundColor="Black"
+                    HorizontalOptions="Center"
+                    Orientation="Horizontal">
                     <Label
-                        FontSize="Large"
+                        FontSize="{StaticResource FontSizeLarge}"
                         Text="TITLE"
                         TextColor="White" />
                 </StackLayout>
@@ -92,17 +92,17 @@
                 <Label Text="Color | Rotation | Pulse | Animated" />
 
                 <StackLayout
-                    HorizontalOptions="CenterAndExpand"
-                    Orientation="Horizontal"
                     Padding="20"
                     touch:TouchEffect.Command="{Binding TouchCommand}"
                     touch:TouchEffect.DefaultAnimationDuration="500"
                     touch:TouchEffect.DefaultBackgroundColor="Gold"
                     touch:TouchEffect.PressedBackgroundColor="Orange"
                     touch:TouchEffect.PressedRotation="15"
-                    touch:TouchEffect.PulseCount="2">
+                    touch:TouchEffect.PulseCount="2"
+                    HorizontalOptions="Center"
+                    Orientation="Horizontal">
                     <Label
-                        FontSize="Large"
+                        FontSize="{StaticResource FontSizeLarge}"
                         Text="TITLE"
                         TextColor="White" />
                 </StackLayout>
@@ -114,12 +114,12 @@
 
                 <Label Text="Button | ImageButton" />
 
-                <Button Text="Button" touch:TouchEffect.Command="{Binding TouchCommand}" />
+                <Button touch:TouchEffect.Command="{Binding TouchCommand}" Text="Button" />
 
                 <ImageButton
+                    touch:TouchEffect.Command="{Binding TouchCommand}"
                     HeightRequest="150"
-                    Source="xamarinstore.jpg"
-                    touch:TouchEffect.Command="{Binding TouchCommand}" />
+                    Source="xamarinstore.jpg" />
 
             </StackLayout>
 
@@ -128,19 +128,19 @@
                 <Label Text="Nested effect" />
 
                 <ContentView
-                    BackgroundColor="Purple"
-                    HorizontalOptions="CenterAndExpand"
                     Padding="50"
                     touch:TouchEffect.Command="{Binding ParentPressedCommand}"
                     touch:TouchEffect.NativeAnimation="True"
-                    touch:TouchEffect.NativeAnimationBorderless="{Binding NativeAnimationBorderless}">
+                    touch:TouchEffect.NativeAnimationBorderless="{Binding NativeAnimationBorderless}"
+                    BackgroundColor="Purple"
+                    HorizontalOptions="Center">
                     <ContentView
-                        BackgroundColor="Gold"
-                        HeightRequest="100"
-                        WidthRequest="100"
                         touch:TouchEffect.Command="{Binding ChildPressedCommand}"
                         touch:TouchEffect.NativeAnimation="True"
-                        touch:TouchEffect.NativeAnimationBorderless="{Binding NativeAnimationBorderless}" />
+                        touch:TouchEffect.NativeAnimationBorderless="{Binding NativeAnimationBorderless}"
+                        BackgroundColor="Gold"
+                        HeightRequest="100"
+                        WidthRequest="100" />
                 </ContentView>
             </StackLayout>
 

--- a/samples/Maui.TouchEffect.Sample/Maui.TouchEffect.Sample/Resources/Styles/Styles.xaml
+++ b/samples/Maui.TouchEffect.Sample/Maui.TouchEffect.Sample/Resources/Styles/Styles.xaml
@@ -1,9 +1,15 @@
 ﻿<?xml version="1.0" encoding="UTF-8" ?>
 <?xaml-comp compile="true" ?>
-<ResourceDictionary
-    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
-    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-    xmlns:ios="clr-namespace:Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific;assembly=Microsoft.Maui.Controls">
+<ResourceDictionary xmlns="http://schemas.microsoft.com/dotnet/2021/maui" xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
+
+    <x:Double x:Key="FontSizeMicro">10</x:Double>
+    <x:Double x:Key="FontSizeSmall">12</x:Double>
+    <x:Double x:Key="FontSizeMedium">14</x:Double>
+    <x:Double x:Key="FontSizeLarge">18</x:Double>
+    <x:Double x:Key="FontSizeBody">17</x:Double>
+    <x:Double x:Key="FontSizeTitle">24</x:Double>
+    <x:Double x:Key="FontSizeHeader">30</x:Double>
+    <x:Double x:Key="FontSizeCaption">12</x:Double>
 
     <Thickness x:Key="ContentPadding">20, 0</Thickness>
 
@@ -135,12 +141,6 @@
         </Setter>
     </Style>
 
-    <Style TargetType="Frame">
-        <Setter Property="HasShadow" Value="False" />
-        <Setter Property="BorderColor" Value="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray950}}" />
-        <Setter Property="CornerRadius" Value="8" />
-    </Style>
-
     <Style TargetType="ImageButton">
         <Setter Property="Opacity" Value="1" />
         <Setter Property="BorderColor" Value="Transparent" />
@@ -180,11 +180,6 @@
                 </VisualStateGroup>
             </VisualStateGroupList>
         </Setter>
-    </Style>
-
-    <Style TargetType="ListView">
-        <Setter Property="SeparatorColor" Value="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray500}}" />
-        <Setter Property="RefreshControlColor" Value="{AppThemeBinding Light={StaticResource Gray900}, Dark={StaticResource Gray200}}" />
     </Style>
 
     <Style TargetType="Picker">
@@ -410,7 +405,6 @@
 
     <Style ApplyToDerivedTypes="True" TargetType="ContentPage">
         <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource AppBackgroundColor}, Dark={StaticResource Gray950}}" />
-        <Setter Property="ios:Page.UseSafeArea" Value="False" />
         <Setter Property="NavigationPage.BackButtonTitle" Value="" />
     </Style>
 

--- a/src/Maui.TouchEffect/GestureManager.cs
+++ b/src/Maui.TouchEffect/GestureManager.cs
@@ -8,7 +8,7 @@ namespace Maui.TouchEffect;
 
 internal sealed class GestureManager : IDisposable, IAsyncDisposable
 {
-    private Color? defaultBackgroundColor;
+    private Color? fallbackBackgroundColor;
 
     CancellationTokenSource? longPressTokenSource, animationTokenSource;
 
@@ -251,7 +251,7 @@ internal sealed class GestureManager : IDisposable, IAsyncDisposable
     internal void Reset()
     {
         SetCustomAnimationTask(null);
-        defaultBackgroundColor = default;
+        fallbackBackgroundColor = default;
     }
 
     internal void AbortAnimations(TouchEffect touchEffect)
@@ -357,11 +357,11 @@ internal sealed class GestureManager : IDisposable, IAsyncDisposable
             return;
         }
 
-        var normalBackgroundImageSource = touchEffect.DefaultImageSource;
+        var defaultBackgroundImageSource = touchEffect.DefaultImageSource;
         var pressedBackgroundImageSource = touchEffect.PressedImageSource;
         var hoveredBackgroundImageSource = touchEffect.HoveredImageSource;
 
-        if (normalBackgroundImageSource == null &&
+        if (defaultBackgroundImageSource == null &&
             pressedBackgroundImageSource == null &&
             hoveredBackgroundImageSource == null)
         {
@@ -459,18 +459,18 @@ internal sealed class GestureManager : IDisposable, IAsyncDisposable
 
     private static Task SetOpacity(TouchEffect sender, TouchState touchState, HoverState hoverState, int duration, Easing easing)
     {
-        var normalOpacity = sender.DefaultOpacity;
+        var defaultOpacity = sender.DefaultOpacity;
         var pressedOpacity = sender.PressedOpacity;
         var hoveredOpacity = sender.HoveredOpacity;
 
-        if (Abs(normalOpacity - 1) <= double.Epsilon &&
+        if (Abs(defaultOpacity - 1) <= double.Epsilon &&
             Abs(pressedOpacity - 1) <= double.Epsilon &&
             Abs(hoveredOpacity - 1) <= double.Epsilon)
         {
             return Task.FromResult(false);
         }
 
-        var opacity = normalOpacity;
+        var opacity = defaultOpacity;
 
         if (touchState == TouchState.Pressed)
         {
@@ -496,18 +496,18 @@ internal sealed class GestureManager : IDisposable, IAsyncDisposable
 
     private Task SetScale(TouchEffect sender, TouchState touchState, HoverState hoverState, int duration, Easing easing)
     {
-        var normalScale = sender.DefaultScale;
+        var defaultScale = sender.DefaultScale;
         var pressedScale = sender.PressedScale;
         var hoveredScale = sender.HoveredScale;
 
-        if (Abs(normalScale - 1) <= double.Epsilon &&
+        if (Abs(defaultScale - 1) <= double.Epsilon &&
             Abs(pressedScale - 1) <= double.Epsilon &&
             Abs(hoveredScale - 1) <= double.Epsilon)
         {
             return Task.FromResult(false);
         }
 
-        var scale = normalScale;
+        var scale = defaultScale;
 
         if (touchState == TouchState.Pressed)
         {
@@ -546,26 +546,26 @@ internal sealed class GestureManager : IDisposable, IAsyncDisposable
 
     private static Task SetTranslation(TouchEffect sender, TouchState touchState, HoverState hoverState, int duration, Easing easing)
     {
-        var normalTranslationX = sender.DefaultTranslationX;
+        var defaultTranslationX = sender.DefaultTranslationX;
         var pressedTranslationX = sender.PressedTranslationX;
         var hoveredTranslationX = sender.HoveredTranslationX;
 
-        var normalTranslationY = sender.DefaultTranslationY;
+        var defaultTranslationY = sender.DefaultTranslationY;
         var pressedTranslationY = sender.PressedTranslationY;
         var hoveredTranslationY = sender.HoveredTranslationY;
 
-        if (Abs(normalTranslationX) <= double.Epsilon
+        if (Abs(defaultTranslationX) <= double.Epsilon
             && Abs(pressedTranslationX) <= double.Epsilon
             && Abs(hoveredTranslationX) <= double.Epsilon
-            && Abs(normalTranslationY) <= double.Epsilon
+            && Abs(defaultTranslationY) <= double.Epsilon
             && Abs(pressedTranslationY) <= double.Epsilon
             && Abs(hoveredTranslationY) <= double.Epsilon)
         {
             return Task.FromResult(false);
         }
 
-        var translationX = normalTranslationX;
-        var translationY = normalTranslationY;
+        var translationX = defaultTranslationX;
+        var translationY = defaultTranslationY;
 
         if (touchState == TouchState.Pressed)
         {
@@ -599,18 +599,18 @@ internal sealed class GestureManager : IDisposable, IAsyncDisposable
 
     private static Task SetRotation(TouchEffect sender, TouchState touchState, HoverState hoverState, int duration, Easing easing)
     {
-        var normalRotation = sender.DefaultRotation;
+        var defaultRotation = sender.DefaultRotation;
         var pressedRotation = sender.PressedRotation;
         var hoveredRotation = sender.HoveredRotation;
 
-        if (Abs(normalRotation) <= double.Epsilon
+        if (Abs(defaultRotation) <= double.Epsilon
             && Abs(pressedRotation) <= double.Epsilon
             && Abs(hoveredRotation) <= double.Epsilon)
         {
             return Task.FromResult(false);
         }
 
-        var rotation = normalRotation;
+        var rotation = defaultRotation;
 
         if (touchState == TouchState.Pressed)
         {
@@ -634,18 +634,18 @@ internal sealed class GestureManager : IDisposable, IAsyncDisposable
 
     private static Task SetRotationX(TouchEffect sender, TouchState touchState, HoverState hoverState, int duration, Easing easing)
     {
-        var normalRotationX = sender.DefaultRotationX;
+        var defaultRotationX = sender.DefaultRotationX;
         var pressedRotationX = sender.PressedRotationX;
         var hoveredRotationX = sender.HoveredRotationX;
 
-        if (Abs(normalRotationX) <= double.Epsilon &&
+        if (Abs(defaultRotationX) <= double.Epsilon &&
             Abs(pressedRotationX) <= double.Epsilon &&
             Abs(hoveredRotationX) <= double.Epsilon)
         {
             return Task.FromResult(false);
         }
 
-        var rotationX = normalRotationX;
+        var rotationX = defaultRotationX;
 
         if (touchState == TouchState.Pressed)
         {
@@ -669,18 +669,18 @@ internal sealed class GestureManager : IDisposable, IAsyncDisposable
 
     private static Task SetRotationY(TouchEffect sender, TouchState touchState, HoverState hoverState, int duration, Easing easing)
     {
-        var normalRotationY = sender.DefaultRotationY;
+        var defaultRotationY = sender.DefaultRotationY;
         var pressedRotationY = sender.PressedRotationY;
         var hoveredRotationY = sender.HoveredRotationY;
 
-        if (Abs(normalRotationY) <= double.Epsilon &&
+        if (Abs(defaultRotationY) <= double.Epsilon &&
             Abs(pressedRotationY) <= double.Epsilon &&
             Abs(hoveredRotationY) <= double.Epsilon)
         {
             return Task.FromResult(false);
         }
 
-        var rotationY = normalRotationY;
+        var rotationY = defaultRotationY;
 
         if (touchState == TouchState.Pressed)
         {
@@ -709,12 +709,12 @@ internal sealed class GestureManager : IDisposable, IAsyncDisposable
             return false;
         }
 
-        var normalBackgroundColor = touchEffect.DefaultBackgroundColor;
+        var defaultBackgroundColor = touchEffect.DefaultBackgroundColor;
         var pressedBackgroundColor = touchEffect.PressedBackgroundColor;
         var hoveredBackgroundColor = touchEffect.HoveredBackgroundColor;
 
         if (touchEffect.Element == null
-            || normalBackgroundColor is null
+            || defaultBackgroundColor is null
             && pressedBackgroundColor is null
             && hoveredBackgroundColor is null)
         {
@@ -723,9 +723,9 @@ internal sealed class GestureManager : IDisposable, IAsyncDisposable
 
         var element = touchEffect.Element;
 
-        defaultBackgroundColor ??= element.BackgroundColor ?? normalBackgroundColor;
+        fallbackBackgroundColor ??= element.BackgroundColor ?? defaultBackgroundColor;
 
-        var updatedBackgroundColor = defaultBackgroundColor;
+        var updatedBackgroundColor = fallbackBackgroundColor;
 
         switch (touchState, hoverState)
         {

--- a/src/Maui.TouchEffect/TouchEffect.shared.cs
+++ b/src/Maui.TouchEffect/TouchEffect.shared.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel;
+using System.ComponentModel;
 using System.Windows.Input;
 using Maui.TouchEffect.Converters;
 using Maui.TouchEffect.Enums;
@@ -600,6 +600,8 @@ public partial class TouchEffect : RoutingEffect
 
     public object? LongPressCommandParameter => GetLongPressCommandParameter(Element);
 
+    // Required for Xaml SG, it will not read from the static methods
+    [TypeConverter(typeof(TimeSpanMillisecondTypeConverter))]
     public TimeSpan LongPressDuration => GetLongPressDuration(Element);
 
     public ImageSource? DefaultImageSource => GetDefaultImageSource(Element);

--- a/src/Maui.TouchEffect/TouchEffect.shared.cs
+++ b/src/Maui.TouchEffect/TouchEffect.shared.cs
@@ -964,7 +964,7 @@ public partial class TouchEffect : RoutingEffect
         return bindable?.GetValue(DefaultBackgroundColorProperty) as Color;
     }
 
-    public static void SetNormalBackgroundColor(BindableObject? bindable, Color value)
+    public static void SetDefaultBackgroundColor(BindableObject? bindable, Color value)
     {
         bindable?.SetValue(DefaultBackgroundColorProperty, value);
     }
@@ -994,7 +994,7 @@ public partial class TouchEffect : RoutingEffect
         return (double)(bindable?.GetValue(DefaultOpacityProperty) ?? throw new ArgumentNullException(nameof(bindable)));
     }
 
-    public static void SetNormalOpacity(BindableObject? bindable, double value)
+    public static void SetDefaultOpacity(BindableObject? bindable, double value)
     {
         bindable?.SetValue(DefaultOpacityProperty, value);
     }
@@ -1024,7 +1024,7 @@ public partial class TouchEffect : RoutingEffect
         return (double)(bindable?.GetValue(DefaultScaleProperty) ?? throw new ArgumentNullException(nameof(bindable)));
     }
 
-    public static void SetNormalScale(BindableObject? bindable, double value)
+    public static void SetDefaultScale(BindableObject? bindable, double value)
     {
         bindable?.SetValue(DefaultScaleProperty, value);
     }
@@ -1054,7 +1054,7 @@ public partial class TouchEffect : RoutingEffect
         return (double)(bindable?.GetValue(DefaultTranslationXProperty) ?? throw new ArgumentNullException(nameof(bindable)));
     }
 
-    public static void SetNormalTranslationX(BindableObject? bindable, double value)
+    public static void SetDefaultTranslationX(BindableObject? bindable, double value)
     {
         bindable?.SetValue(DefaultTranslationXProperty, value);
     }
@@ -1084,7 +1084,7 @@ public partial class TouchEffect : RoutingEffect
         return (double)(bindable?.GetValue(DefaultTranslationYProperty) ?? throw new ArgumentNullException(nameof(bindable)));
     }
 
-    public static void SetNormalTranslationY(BindableObject? bindable, double value)
+    public static void SetDefaultTranslationY(BindableObject? bindable, double value)
     {
         bindable?.SetValue(DefaultTranslationYProperty, value);
     }
@@ -1114,7 +1114,7 @@ public partial class TouchEffect : RoutingEffect
         return (double)(bindable?.GetValue(DefaultRotationProperty) ?? throw new ArgumentNullException(nameof(bindable)));
     }
 
-    public static void SetNormalRotation(BindableObject? bindable, double value)
+    public static void SetDefaultRotation(BindableObject? bindable, double value)
     {
         bindable?.SetValue(DefaultRotationProperty, value);
     }
@@ -1144,7 +1144,7 @@ public partial class TouchEffect : RoutingEffect
         return (double)(bindable?.GetValue(DefaultRotationXProperty) ?? throw new ArgumentNullException(nameof(bindable)));
     }
 
-    public static void SetNormalRotationX(BindableObject? bindable, double value)
+    public static void SetDefaultRotationX(BindableObject? bindable, double value)
     {
         bindable?.SetValue(DefaultRotationXProperty, value);
     }
@@ -1174,7 +1174,7 @@ public partial class TouchEffect : RoutingEffect
         return (double)(bindable?.GetValue(DefaultRotationYProperty) ?? throw new ArgumentNullException(nameof(bindable)));
     }
 
-    public static void SetNormalRotationY(BindableObject? bindable, double value)
+    public static void SetDefaultRotationY(BindableObject? bindable, double value)
     {
         bindable?.SetValue(DefaultRotationYProperty, value);
     }
@@ -1229,7 +1229,7 @@ public partial class TouchEffect : RoutingEffect
         return (int)(bindable?.GetValue(DefaultAnimationDurationProperty) ?? throw new ArgumentNullException(nameof(bindable)));
     }
 
-    public static void SetNormalAnimationDuration(BindableObject? bindable, int value)
+    public static void SetDefaultAnimationDuration(BindableObject? bindable, int value)
     {
         bindable?.SetValue(DefaultAnimationDurationProperty, value);
     }
@@ -1244,7 +1244,7 @@ public partial class TouchEffect : RoutingEffect
         return (Easing?)bindable.GetValue(DefaultAnimationEasingProperty);
     }
 
-    public static void SetNormalAnimationEasing(BindableObject? bindable, Easing? value)
+    public static void SetDefaultAnimationEasing(BindableObject? bindable, Easing? value)
     {
         bindable?.SetValue(DefaultAnimationEasingProperty, value);
     }


### PR DESCRIPTION
One I noticed in a project, enabling xaml source gen would cause any element using LongPressDuration to crash when touched. The reason for this was the type converters on the static methods never got invoked, this has been added to the instance property to invoke the type converter, the old type converters are still there and this still works without Xaml SG.

Breaking change: all properties called normal are now named default. This is to keep the api as closely aligned with the community toolkit as possible.